### PR TITLE
Fix Node.update to handle float reward properly

### DIFF
--- a/src/classNode.py
+++ b/src/classNode.py
@@ -17,14 +17,12 @@ class Node:
     def is_fully_expanded(self) -> bool:
         return len(self.children) == len(list(self.board.legal_moves))
 
-    def update(self, reward: int):
+    def update(self, reward: float):
         self.visits += 1
-        if self.board.turn == chess.WHITE and reward == 1:
-            self.value += 1
-        elif self.board.turn == chess.BLACK and reward == -1:
-            self.value += 1
-        elif reward == 0.5:
-            self.value += reward
+        if reward == 0.5:
+            self.value += 0.5
+        else:
+            self.value += reward if self.board.turn == chess.WHITE else -reward
         if self.parent:
             self.rating = self.value / self.visits
             self.parent.update(reward)


### PR DESCRIPTION
## Summary
- allow Node.update to accept a float reward
- adjust value update based on board turn

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684633deaa848330bf975d79959d2f77