### PR TITLE
Update best_child to maximize rating

### DIFF
--- a/src/monte_carlo.py
+++ b/src/monte_carlo.py
@@ -57,7 +57,7 @@ def best_child(root: Node) -> Node:
     #     if avaliation > best_avaliation:
     #         best_avaliation = avaliation
     #         best_child = child
-    best_child = min(root.children, key=lambda x: x.rating)
+    best_child = max(root.children, key=lambda x: x.rating)
     return best_child
 
 def mcts_worker(root, n_simulations):


### PR DESCRIPTION
## Summary
- update `best_child` in `monte_carlo.py` to use `max` when selecting by rating

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c8e048008330a16bd853f46b921b