### PR TITLE
fix(mcts): corrige lógica de seleção, expansão, backprop e merge

### DIFF
--- a/src/classNode.py
+++ b/src/classNode.py
@@ -1,7 +1,7 @@
 import random
 import chess
-import copy
 from typing import Optional, List
+
 
 class Node:
     def __init__(self, board: chess.Board, parent: Optional['Node'] = None, from_move: Optional[chess.Move] = None):
@@ -10,34 +10,40 @@ class Node:
         self.from_move = from_move
         self.children: List['Node'] = []
         self.visits = 0
-        self.value = 0
-        self.rating = 0
-        self.used_moves = set()  # Rastreamento dos movimentos já usados
+        self.value = 0.0
+        self._untried_moves: Optional[List[chess.Move]] = None
+
+    def _ensure_untried(self) -> List[chess.Move]:
+        if self._untried_moves is None:
+            self._untried_moves = list(self.board.legal_moves)
+            random.shuffle(self._untried_moves)
+        return self._untried_moves
 
     def is_fully_expanded(self) -> bool:
-        return len(self.children) == len(list(self.board.legal_moves))
+        return not self._ensure_untried()
 
-    def update(self, reward: float):
+    def is_terminal(self) -> bool:
+        return self.board.is_game_over()
+
+    @property
+    def rating(self) -> float:
+        return self.value / self.visits if self.visits else 0.0
+
+    def update(self, reward: float) -> None:
+        # reward is from White's perspective: +1 White wins, -1 Black wins, 0 draw.
+        # Each node stores value from the perspective of the side to move at the node.
         self.visits += 1
-        if reward == 0.5:
-            self.value += 0.5
-        else:
-            self.value += reward if self.board.turn == chess.WHITE else -reward
-        if self.parent:
-            self.rating = self.value / self.visits
+        self.value += reward if self.board.turn == chess.WHITE else -reward
+        if self.parent is not None:
             self.parent.update(reward)
 
     def expand(self) -> Optional['Node']:
-        legal_moves = list(self.board.legal_moves)
-        available_moves = [move for move in legal_moves if move not in self.used_moves]
-        if available_moves:
-            move = random.choice(available_moves)
-            self.used_moves.add(move)  # Marcar o movimento como usado
-            available_moves.remove(move)
-            new_board = copy.deepcopy(self.board)
-            new_board.push(move)
-            leaf = Node(new_board, parent=self, from_move=move)
-            self.children.append(leaf)
-            return leaf
-        else:
+        untried = self._ensure_untried()
+        if not untried:
             return None
+        move = untried.pop()
+        new_board = self.board.copy(stack=False)
+        new_board.push(move)
+        leaf = Node(new_board, parent=self, from_move=move)
+        self.children.append(leaf)
+        return leaf

--- a/src/game_simulation.py
+++ b/src/game_simulation.py
@@ -1,58 +1,55 @@
 import chess
 import chess.pgn
+
 from classNode import Node
 from monte_carlo import monte_carlo_tree_search
 
-def play_game():
 
-    board = chess.Board()
-    initial_fen =  "Q4r2/R5pp/1p1k4/3p4/2b3P1/8/5q2/1N5K b - - 0 1"
-
-    board.set_fen(initial_fen)
-
+def play_game(initial_fen: str = chess.STARTING_FEN, simulations: int = 3000, processes: int = 1) -> chess.pgn.Game:
+    board = chess.Board(initial_fen)
     print(board)
-    move_history = []
 
     game = chess.pgn.Game()
     game.headers["Event"] = "Test"
     game.headers["White"] = "MCTS"
     game.headers["Black"] = "MCTS"
-    game.headers["SetUp"] = "1"
-    game.headers["FEN"] = initial_fen
+    if initial_fen != chess.STARTING_FEN:
+        game.headers["SetUp"] = "1"
+        game.headers["FEN"] = initial_fen
 
-    root = Node(board)
-    while not board.is_game_over():
-        if board.turn == chess.WHITE:
-            root, move = monte_carlo_tree_search(root, 3000, 10)
-            print(f"Player WHITE move: {board.san(move)}")
-        else:
-            root, move = monte_carlo_tree_search(root, 3000, 10)
-            print(f"Player BLACK move: {board.san(move)}")
+    move_history = []
+    root = Node(board.copy(stack=False))
 
-        move_history.append(board.san(move))
+    while not board.is_game_over(claim_draw=True):
+        root, move = monte_carlo_tree_search(root, simulations, processes)
+        if move is None:
+            break
+
+        side = "WHITE" if board.turn == chess.WHITE else "BLACK"
+        san = board.san(move)
+        print(f"Player {side} move: {san}")
+        move_history.append(san)
         board.push(move)
 
-        if board.is_checkmate():
-            print(f'Player {"WHITE" if board.turn == chess.BLACK else "BLACK"} Wins!')
-            game.headers["Result"] = board.result()
-            break
-        elif board.is_stalemate() or board.is_insufficient_material() or board.is_seventyfive_moves() or board.is_fivefold_repetition():
-            print('Draw!')
-            game.headers["Result"] = board.result()
-            break
-    
+    if board.is_checkmate():
+        winner = "WHITE" if board.turn == chess.BLACK else "BLACK"
+        print(f'Player {winner} Wins!')
+    else:
+        print('Draw!')
+    game.headers["Result"] = board.result(claim_draw=True)
+
+    # Rebuild PGN main line from the recorded SAN history.
     node = game
-    board = chess.Board()  # Resetar o tabuleiro para a posição inicial
-    board.set_fen(initial_fen)  # Redefinir a posição inicial
-
-    for move in move_history:
-        move = board.parse_san(move)  # Converter SAN para objeto Move
+    replay = chess.Board(initial_fen)
+    for san in move_history:
+        move = replay.parse_san(san)
         node = node.add_main_variation(move)
-        board.push(move)  # Atualizar o tabuleiro com o movimento
+        replay.push(move)
 
-    # Imprimir o histórico de movimentos
     print("\nHistórico de movimentos:")
     print(game)
+    return game
+
 
 if __name__ == "__main__":
     play_game()

--- a/src/monte_carlo.py
+++ b/src/monte_carlo.py
@@ -1,106 +1,158 @@
-import copy
 import math
 import random
 import multiprocessing
+from typing import Optional, Tuple
+
+import chess
+
 from classNode import Node
 
+
+C_PUCT = math.sqrt(2)
+
+# Piece values for the rollout material evaluation (White's perspective).
+_PIECE_VALUES = {
+    chess.PAWN: 1.0,
+    chess.KNIGHT: 3.0,
+    chess.BISHOP: 3.0,
+    chess.ROOK: 5.0,
+    chess.QUEEN: 9.0,
+    chess.KING: 0.0,
+}
+
+# Scale that maps a typical decisive material edge to a strong signal in [-1, 1].
+# ~10 points (queen-ish advantage) saturates the heuristic, so a free knight (~3) reads as a clear plus.
+_MATERIAL_SCALE = 10.0
+
+
+def _terminal_reward(board: chess.Board) -> float:
+    """Reward from White's perspective for a finished game."""
+    result = board.result(claim_draw=True)
+    if result == '1-0':
+        return 1.0
+    if result == '0-1':
+        return -1.0
+    return 0.0
+
+
+def _material_eval(board: chess.Board) -> float:
+    """Normalized material balance in [-1, 1] from White's perspective."""
+    score = 0.0
+    for piece_type, value in _PIECE_VALUES.items():
+        score += value * len(board.pieces(piece_type, chess.WHITE))
+        score -= value * len(board.pieces(piece_type, chess.BLACK))
+    return max(-1.0, min(1.0, score / _MATERIAL_SCALE))
+
+
 def uct(node: Node) -> float:
-    # UCT formula: Q + C * sqrt(ln(N) / n)
     if node.visits == 0:
         return float('inf')
-    C = math.sqrt(2) # Exploração constante, ajustável
+    if node.parent is None:
+        return node.value / node.visits
+    # Q is negated: a child's stored value is from the opponent's perspective
+    # relative to the parent that is choosing among its children.
+    exploitation = -node.value / node.visits
+    exploration = C_PUCT * math.sqrt(math.log(node.parent.visits) / node.visits)
+    return exploitation + exploration
 
-    return node.value / node.visits + C * math.sqrt(math.log(node.parent.visits) / node.visits)
 
 def selection(node: Node) -> Node:
-    while node.is_fully_expanded():
-        if not node.children:  # Verifica se a lista children está vazia
+    while not node.is_terminal() and node.is_fully_expanded():
+        if not node.children:
             return node
         node = max(node.children, key=uct)
     return node
 
+
 def expansion(node: Node) -> Node:
-    if not node.is_fully_expanded():
-        node.expand()
-        children = max(node.children, key=uct)
-        return children
-    else:
-        if node.children:
-            children = max(node.children, key=uct)
-            return children
-        else:
-            return node    
+    if node.is_terminal():
+        return node
+    leaf = node.expand()
+    return leaf if leaf is not None else node
 
-def simulation(node: Node) -> int:
-    board = copy.deepcopy(node.board)
-    while not board.is_game_over():
-        legal_moves = list(board.legal_moves)
-        move = random.choice(legal_moves)
-        board.push(move)
-    result = board.result()
-    if result == '1-0':
-        reward = 1
-    elif result == '0-1':
-        reward = -1
-    else:
-        reward = 0.5
-    return reward
 
-def backpropagation(reward: int, node: Node) -> None:
+def simulation(node: Node, max_depth: int = 40) -> float:
+    """Random playout with depth cutoff and material fallback. Returns reward in [-1, 1] (White's POV)."""
+    board = node.board.copy(stack=False)
+    depth = 0
+    while not board.is_game_over(claim_draw=True) and depth < max_depth:
+        moves = list(board.legal_moves)
+        if not moves:
+            break
+        board.push(random.choice(moves))
+        depth += 1
+
+    if board.is_game_over(claim_draw=True):
+        return _terminal_reward(board)
+    return _material_eval(board)
+
+
+def backpropagation(reward: float, node: Node) -> None:
     node.update(reward)
 
+
 def best_child(root: Node) -> Node:
-    # best_child = random.choice(root.children)
-    # best_avaliation = -float('inf')
-    # for child in root.children:
-    #     avaliation = 1 - (child.value / child.visits)
-    #     if avaliation > best_avaliation:
-    #         best_avaliation = avaliation
-    #         best_child = child
-    best_child = max(root.children, key=lambda x: x.rating)
-    return best_child
+    # Most-visited child is the standard, more robust choice than mean value.
+    return max(root.children, key=lambda c: c.visits)
 
-def mcts_worker(root, n_simulations):
-    """
-    Função que cada processo vai executar. Ela cria um novo nó raiz baseado no estado do tabuleiro
-    e realiza simulações, retornando uma lista de atualizações de valor e visitas para retropropagação.
-    """
-    root = copy.deepcopy(root)  # Cria uma nova cópia do nó raiz para o processo
 
+def _run_simulations(root: Node, n_simulations: int) -> None:
     for _ in range(n_simulations):
-        leaf = selection(root) 
-        node = expansion(leaf)  
-        reward = simulation(node) 
+        leaf = selection(root)
+        node = expansion(leaf)
+        reward = simulation(node)
         backpropagation(reward, node)
 
+
+def _mcts_worker(args):
+    root, n_simulations, seed = args
+    random.seed(seed)
+    _run_simulations(root, n_simulations)
     return root
 
-def merge_trees(main_root, temp_root):
-    """
-    Função para combinar os resultados das árvores de cada processo na árvore principal.
-    """
-    main_root.value += temp_root.value
-    main_root.visits += temp_root.visits
-    
-    for child in temp_root.children:
-        main_child = next((temp_child for temp_child in main_root.children if temp_child.from_move == child.from_move), None)
-        if main_child:
-            main_child.visits += child.visits
-            main_child.value += child.value
+
+def _merge_trees(main: Node, other: Node) -> None:
+    """Recursively merge `other` into `main`. Both must represent the same board state."""
+    main.visits += other.visits
+    main.value += other.value
+
+    main_by_move = {c.from_move: c for c in main.children}
+    for other_child in other.children:
+        existing = main_by_move.get(other_child.from_move)
+        if existing is not None:
+            _merge_trees(existing, other_child)
         else:
-            main_root.children.append(child)
-            main_root.used_moves.add(child.from_move)
+            other_child.parent = main
+            main.children.append(other_child)
+            main_by_move[other_child.from_move] = other_child
+            # If main had this move queued as untried, remove it.
+            if main._untried_moves is not None:
+                try:
+                    main._untried_moves.remove(other_child.from_move)
+                except ValueError:
+                    pass
 
-def monte_carlo_tree_search(root: Node, n_simulations: int, n_processes: int = 4):
-    simulations_per_process = n_simulations // n_processes
-    with multiprocessing.Pool(processes=n_processes) as pool:
-        results = pool.starmap(mcts_worker, [(root, simulations_per_process) for _ in range(n_processes)])
 
-    # Combina os resultados das árvores de cada processo na árvore principal
-    for temp_root in results:
-        merge_trees(root, temp_root)
+def monte_carlo_tree_search(
+    root: Node,
+    n_simulations: int,
+    n_processes: int = 1,
+) -> Tuple[Node, Optional[chess.Move]]:
+    # Detach the root from any stale ancestor tree so backprop and deepcopies stay bounded.
+    root.parent = None
 
-    # Seleciona o melhor movimento após todas as simulações
+    if n_processes <= 1:
+        _run_simulations(root, n_simulations)
+    else:
+        simulations_per_process = max(1, n_simulations // n_processes)
+        args = [(root, simulations_per_process, random.randint(0, 2**31 - 1)) for _ in range(n_processes)]
+        with multiprocessing.Pool(processes=n_processes) as pool:
+            results = pool.map(_mcts_worker, args)
+        for temp_root in results:
+            _merge_trees(root, temp_root)
+
+    if not root.children:
+        return root, None
+
     best = best_child(root)
-    move = best.from_move
-    return best, move
+    return best, best.from_move


### PR DESCRIPTION
- Node.update: remove caso especial 0.5 e usa convenção -1/0/+1 (POV brancas)
- Node.expand: usa board.copy() e cacheia movimentos não tentados
- uct: nega Q (perspectiva do oponente) e trata root sem parent
- expansion: retorna o leaf recém-criado em vez de re-selecionar pelo UCT
- simulation: rollout com cutoff de profundidade + avaliação de material
  como fallback (rollouts aleatórios puros em xadrez quase sempre empatam)
- best_child: escolhe por visits (mais robusto que rating médio)
- merge_trees: agora é recursivo, preserva subárvores e reata parents
- monte_carlo_tree_search: detacha root.parent ao reusar a árvore entre
  jogadas, evitando contaminação de backprop em ancestrais obsoletos
- game_simulation: remove branching duplicado WHITE/BLACK e usa Board.copy
